### PR TITLE
Bump stylelint-color-format version

### DIFF
--- a/packages/stylelint-config-scss/package.json
+++ b/packages/stylelint-config-scss/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "style-search": "^0.1.0",
-    "stylelint-color-format": "^1.0.0",
+    "stylelint-color-format": "^1.1.0",
     "stylelint-config-recommended-scss": "^4.0.0",
     "stylelint-config-standard": "^20.0.0",
     "stylelint-csstree-validator": "^1.5.2",


### PR DESCRIPTION
v1.1.0 allows to provide [custom error message](https://github.com/filipekiss/stylelint-color-format/issues/9#event-3218613366)