### PR TITLE
Relax stylelint peerDependency restriction for stylelint-config-scss

### DIFF
--- a/packages/stylelint-config-scss/package.json
+++ b/packages/stylelint-config-scss/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "peerDependencies": {
-    "stylelint": "^11.1.0"
+    "stylelint": ">=11.1.0"
   },
   "dependencies": {
     "style-search": "^0.1.0",


### PR DESCRIPTION
# Why

`stylelint` has a version [12.x](https://github.com/stylelint/stylelint/releases/tag/12.0.0) and [13,x](https://github.com/stylelint/stylelint/releases/tag/13.0.0), it would be nice if this wouldn't restrict to use the older version 11.x since there shouldn't be major incompatibilities (?).

# What

Relax the [peerDependency](https://nodejs.org/es/blog/npm/peer-dependencies/) for `stylelint`